### PR TITLE
Add Discord webhooks

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,6 +18,7 @@ jobs:
   global_infra:
     name: "Global"
     uses: osinfra-io/github-terraform-called-workflows/.github/workflows/plan-and-apply.yml@v0.1.8
+    if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       environment: production
@@ -34,5 +35,6 @@ jobs:
       infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}
       terraform_plan_secret_args: >-
         -var=billing_email=${{ secrets.BILLING_EMAIL }}
+        -var=discord_webhook_api_key=${{ secrets.DISCORD_WEBHOOK_API_KEY }}
         -var=datadog_webhook_api_key=${{ secrets.DATADOG_WEBHOOK_API_KEY }}
         -var=github_token=${{ secrets.ORGANIZATION_MANAGEMENT_WORKFLOW }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.83.6
     hooks:
       - id: terraform_fmt
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 5.41.0 |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.42.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
@@ -31,6 +31,7 @@ No modules.
 | [github_repository.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 | [github_repository_file.security_policy](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | resource |
 | [github_repository_webhook.datadog](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_webhook) | resource |
+| [github_repository_webhook.discord](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_webhook) | resource |
 | [github_team.children](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team) | resource |
 | [github_team.parents](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team) | resource |
 | [github_team_members.children](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_members) | resource |
@@ -49,10 +50,11 @@ No modules.
 | <a name="input_admins"></a> [admins](#input\_admins) | A set of admins to add to the organization | `set(string)` | n/a | yes |
 | <a name="input_billing_email"></a> [billing\_email](#input\_billing\_email) | The billing email address for the organization | `string` | n/a | yes |
 | <a name="input_datadog_webhook_api_key"></a> [datadog\_webhook\_api\_key](#input\_datadog\_webhook\_api\_key) | The Datadog API key used for creating webhooks | `string` | n/a | yes |
+| <a name="input_discord_webhook_api_key"></a> [discord\_webhook\_api\_key](#input\_discord\_webhook\_api\_key) | The Discord API key used for creating webhooks | `string` | n/a | yes |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | The GitHub token used for managing the organization | `string` | n/a | yes |
 | <a name="input_members"></a> [members](#input\_members) | A set of members to add to the organization | `set(string)` | `[]` | no |
 | <a name="input_organization_secrets"></a> [organization\_secrets](#input\_organization\_secrets) | Map of secrets to add to the organization | <pre>map(object({<br>    description = string<br>    visibility  = string<br>  }))</pre> | n/a | yes |
-| <a name="input_repositories"></a> [repositories](#input\_repositories) | Map of repositories to create | <pre>map(object({<br>    description                     = string<br>    enable_branch_protection        = optional(bool, true)<br>    enable_datadog_webhook          = optional(bool, true)<br>    has_discussions                 = optional(bool, false)<br>    is_template                     = optional(bool, false)<br>    push_restrictions               = optional(list(string), [])<br>    required_status_checks_contexts = optional(list(string), [])<br>    template                        = optional(string)<br>    topics                          = optional(list(string))<br><br>    # In most cases, the visibility of your organizations repository should be private.<br>    # However, we are keeping our code public to encourage others to learn from our work.<br><br>    visibility = optional(string, "public")<br>  }))</pre> | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | Map of repositories to create | <pre>map(object({<br>    description                     = string<br>    enable_branch_protection        = optional(bool, true)<br>    enable_discord_webhook          = optional(bool, true)<br>    enable_datadog_webhook          = optional(bool, true)<br>    has_discussions                 = optional(bool, false)<br>    is_template                     = optional(bool, false)<br>    push_restrictions               = optional(list(string), [])<br>    required_status_checks_contexts = optional(list(string), [])<br>    template                        = optional(string)<br>    topics                          = optional(list(string))<br><br>    # In most cases, the visibility of your organizations repository should be private.<br>    # However, we are keeping our code public to encourage others to learn from our work.<br><br>    visibility = optional(string, "public")<br>  }))</pre> | n/a | yes |
 | <a name="input_team_children"></a> [team\_children](#input\_team\_children) | Map of child teams to create | <pre>map(object({<br>    description     = string<br>    maintainers     = optional(set(string), [])<br>    members         = optional(set(string), [])<br>    permission      = optional(string, null)<br>    parent_team_key = string<br>    repositories    = optional(set(string), [])<br>  }))</pre> | n/a | yes |
 | <a name="input_team_parents"></a> [team\_parents](#input\_team\_parents) | Map of parent teams to create | <pre>map(object({<br>    description               = string<br>    maintainers               = optional(set(string), [])<br>    members                   = optional(set(string), [])<br>    permission                = optional(string, null)<br>    privacy                   = optional(string, "closed")<br>    repositories              = optional(set(string), [])<br>    review_request_delegation = optional(bool, false)<br>  }))</pre> | n/a | yes |
 

--- a/global/infra/locals.tf
+++ b/global/infra/locals.tf
@@ -27,6 +27,10 @@ locals {
     for repository_key, repository in var.repositories : repository_key => repository if repository.enable_datadog_webhook
   }
 
+  discord_webhooks = {
+    for repository_key, repository in var.repositories : repository_key => repository if repository.enable_discord_webhook
+  }
+
   members = {
     for user in var.members : user => "member"
   }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -233,6 +233,10 @@ resource "github_repository_webhook" "discord" {
 
   events     = ["*"]
   repository = each.key
+
+  depends_on = [
+    github_repository.this
+  ]
 }
 
 resource "github_repository_webhook" "datadog" {
@@ -260,6 +264,10 @@ resource "github_repository_webhook" "datadog" {
   ]
 
   repository = each.key
+
+  depends_on = [
+    github_repository.this
+  ]
 }
 
 # Github Team Resource

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -228,7 +228,7 @@ resource "github_repository_webhook" "discord" {
   configuration {
     content_type = "json"
     insecure_ssl = false
-    url          = "https://discord.com/api/webhooks/1175823442415722517/${var.discord_webhook_api_key}"
+    url          = "https://discord.com/api/webhooks/1175823442415722517/${var.discord_webhook_api_key}/github"
   }
 
   events     = ["*"]

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -220,6 +220,21 @@ resource "github_repository_file" "security_policy" {
 # Github Repository Webhook Resource
 # https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_webhook
 
+resource "github_repository_webhook" "discord" {
+  for_each = local.discord_webhooks
+
+  active = true
+
+  configuration {
+    content_type = "json"
+    insecure_ssl = false
+    url          = "https://discord.com/api/webhooks/1175823442415722517/${var.discord_webhook_api_key}"
+  }
+
+  events     = ["*"]
+  repository = each.key
+}
+
 resource "github_repository_webhook" "datadog" {
   for_each = local.datadog_webhooks
 

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -11,6 +11,11 @@ variable "billing_email" {
   type        = string
   sensitive   = true
 }
+variable "discord_webhook_api_key" {
+  description = "The Discord API key used for creating webhooks"
+  type        = string
+  sensitive   = true
+}
 
 variable "datadog_webhook_api_key" {
   description = "The Datadog API key used for creating webhooks"
@@ -43,6 +48,7 @@ variable "repositories" {
   type = map(object({
     description                     = string
     enable_branch_protection        = optional(bool, true)
+    enable_discord_webhook          = optional(bool, true)
     enable_datadog_webhook          = optional(bool, true)
     has_discussions                 = optional(bool, false)
     is_template                     = optional(bool, false)


### PR DESCRIPTION
This pull request adds support for Discord webhooks. The Discord webhooks are configured to send events to a Discord channel using the provided API key.

Fixes #130 