### PR TITLE
Fix restrict pushes breaking change in v6.0.0 Terraform provider for Github

### DIFF
--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,10 +9,10 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 5.42.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.10.0 |
 
 ## Modules
 
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | The GitHub token used for managing the organization | `string` | n/a | yes |
 | <a name="input_members"></a> [members](#input\_members) | A set of members to add to the organization | `set(string)` | `[]` | no |
 | <a name="input_organization_secrets"></a> [organization\_secrets](#input\_organization\_secrets) | Map of secrets to add to the organization | <pre>map(object({<br>    description = string<br>    visibility  = string<br>  }))</pre> | n/a | yes |
-| <a name="input_repositories"></a> [repositories](#input\_repositories) | Map of repositories to create | <pre>map(object({<br>    description                     = string<br>    enable_branch_protection        = optional(bool, true)<br>    enable_discord_webhook          = optional(bool, true)<br>    enable_datadog_webhook          = optional(bool, true)<br>    has_discussions                 = optional(bool, false)<br>    is_template                     = optional(bool, false)<br>    push_restrictions               = optional(list(string), [])<br>    required_status_checks_contexts = optional(list(string), [])<br>    template                        = optional(string)<br>    topics                          = optional(list(string))<br><br>    # In most cases, the visibility of your organizations repository should be private.<br>    # However, we are keeping our code public to encourage others to learn from our work.<br><br>    visibility = optional(string, "public")<br>  }))</pre> | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | Map of repositories to create | <pre>map(object({<br>    description                     = string<br>    enable_branch_protection        = optional(bool, true)<br>    enable_discord_webhook          = optional(bool, true)<br>    enable_datadog_webhook          = optional(bool, true)<br>    has_discussions                 = optional(bool, false)<br>    is_template                     = optional(bool, false)<br>    push_allowances                 = optional(list(string), [])<br>    required_status_checks_contexts = optional(list(string), [])<br>    template                        = optional(string)<br>    topics                          = optional(list(string))<br><br>    # In most cases, the visibility of your organizations repository should be private.<br>    # However, we are keeping our code public to encourage others to learn from our work.<br><br>    visibility = optional(string, "public")<br>  }))</pre> | n/a | yes |
 | <a name="input_team_children"></a> [team\_children](#input\_team\_children) | Map of child teams to create | <pre>map(object({<br>    description     = string<br>    maintainers     = optional(set(string), [])<br>    members         = optional(set(string), [])<br>    permission      = optional(string, null)<br>    parent_team_key = string<br>    repositories    = optional(set(string), [])<br>  }))</pre> | n/a | yes |
 | <a name="input_team_parents"></a> [team\_parents](#input\_team\_parents) | Map of parent teams to create | <pre>map(object({<br>    description               = string<br>    maintainers               = optional(set(string), [])<br>    members                   = optional(set(string), [])<br>    permission                = optional(string, null)<br>    privacy                   = optional(string, "closed")<br>    repositories              = optional(set(string), [])<br>    review_request_delegation = optional(bool, false)<br>  }))</pre> | n/a | yes |
 

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -89,7 +89,6 @@ resource "github_branch_protection" "this" {
 
   enforce_admins                  = false
   pattern                         = "main"
-  push_restrictions               = each.value.push_restrictions
   repository_id                   = github_repository.this[each.key].name
   require_conversation_resolution = true
   required_linear_history         = true
@@ -104,6 +103,10 @@ resource "github_branch_protection" "this" {
   required_status_checks {
     contexts = each.value.required_status_checks_contexts
     strict   = true
+  }
+
+  restrict_pushes {
+    push_allowances = each.value.push_allowances
   }
 }
 

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -25,7 +25,7 @@ repositories = {
       "platform-team"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -41,7 +41,7 @@ repositories = {
       "platform-team"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
 
@@ -61,7 +61,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-backstage"
     ]
   }
@@ -128,7 +128,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -144,7 +144,7 @@ repositories = {
       "platform-team"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -161,7 +161,7 @@ repositories = {
       "platform-team"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -178,7 +178,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -197,7 +197,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -216,7 +216,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -234,7 +234,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -254,7 +254,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-github"
     ]
   }
@@ -271,7 +271,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -288,7 +288,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -307,7 +307,7 @@ repositories = {
       "testing"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -325,7 +325,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-kubernetes"
     ]
   }
@@ -342,7 +342,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -359,7 +359,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -376,7 +376,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -393,7 +393,7 @@ repositories = {
       "terraform"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-google-cloud-landing-zone"
     ]
   }
@@ -624,7 +624,7 @@ repositories = {
       "vault"
     ]
 
-    push_restrictions = [
+    push_allowances = [
       "osinfra-io/platform-vault"
     ]
   }

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -52,7 +52,7 @@ variable "repositories" {
     enable_datadog_webhook          = optional(bool, true)
     has_discussions                 = optional(bool, false)
     is_template                     = optional(bool, false)
-    push_restrictions               = optional(list(string), [])
+    push_allowances                 = optional(list(string), [])
     required_status_checks_contexts = optional(list(string), [])
     template                        = optional(string)
     topics                          = optional(list(string))


### PR DESCRIPTION
Looks like this PR: https://github.com/integrations/terraform-provider-github/pull/2045 introduced a breaking change in the v6.0.0 release of the Terraform provider for GitHub. No note of breaking changes on the release page but it was a major release so breaking changes are likely. https://github.com/integrations/terraform-provider-github/releases/tag/v6.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation to reflect changes in version updates for various providers and modifications in access control configurations.
- **Chores**
	- Renamed `push_restrictions` to `push_allowances` across various configuration files to enhance clarity in access control settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->