### PR TITLE
Rename customer acquisition to customer trust

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-update-repository.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-repository.yml
@@ -26,7 +26,7 @@ body:
       label: "Team name:"
       description: Select the team that will own this repository. If you don't see your team, please use the add or update team service interface.
       options:
-        - stream-customer-acquisition
+        - stream-customer-trust
         - platform-github
         - platform-google-cloud-landing-zone
     validations:

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -66,8 +66,8 @@ repositories = {
     ]
   }
 
-  "ca-google-cloud-kubernetes" = {
-    description = "Kubernetes Infrastructure as Code (IaC) example for the Customer Acquisition stream-aligned team."
+  "ct-google-cloud-kubernetes" = {
+    description = "Kubernetes Infrastructure as Code (IaC) example for the Customer Trust stream-aligned team."
 
     topics = [
       "customer-acquisition",
@@ -512,8 +512,8 @@ repositories = {
     ]
   }
 
-  "stream-customer-acquisition" = {
-    description              = "Stream Aligned Team: responsible for the Customer Acquisition stream."
+  "stream-customer-trust" = {
+    description              = "Stream Aligned Team: responsible for the Customer Trust stream."
     enable_branch_protection = false
     enable_datadog_webhook   = false
 
@@ -850,37 +850,37 @@ team_children = {
     ]
   }
 
-  "stream-customer-acquisition-approvers-nonprod" = {
-    description     = "Stream Aligned Team: responsible for Customer Acquisition workflow approvals in the Non-Production environments."
-    parent_team_key = "stream-customer-acquisition"
+  "stream-customer-trust-approvers-nonprod" = {
+    description     = "Stream Aligned Team: responsible for Customer Trust workflow approvals in the Non-Production environments."
+    parent_team_key = "stream-customer-trust"
     maintainers     = ["brettcurtis"]
     members         = []
   }
 
-  "stream-customer-acquisition-approvers-prod" = {
-    description     = "Stream Aligned Team: responsible for Customer Acquisition workflow approvals in the Production environment."
-    parent_team_key = "stream-customer-acquisition"
+  "stream-customer-trust-approvers-prod" = {
+    description     = "Stream Aligned Team: responsible for Customer Trust workflow approvals in the Production environment."
+    parent_team_key = "stream-customer-trust"
     maintainers     = ["brettcurtis"]
     members         = []
   }
 
-  "stream-customer-acquisition-approvers-sb" = {
-    description     = "Stream Aligned Team: responsible for Customer Acquisition workflow approvals in the Sandbox environment."
-    parent_team_key = "stream-customer-acquisition"
+  "stream-customer-trust-approvers-sb" = {
+    description     = "Stream Aligned Team: responsible for Customer Trust workflow approvals in the Sandbox environment."
+    parent_team_key = "stream-customer-trust"
     maintainers     = ["brettcurtis"]
     members         = []
   }
 
-  "stream-customer-acquisition-repository-admins" = {
-    description     = "Stream Aligned Team: responsible for Customer Acquisition repository administration."
-    parent_team_key = "stream-customer-acquisition"
+  "stream-customer-trust-repository-admins" = {
+    description     = "Stream Aligned Team: responsible for Customer Trust repository administration."
+    parent_team_key = "stream-customer-trust"
     permission      = "admin"
     maintainers     = ["brettcurtis"]
     members         = []
 
     repositories = [
-      "ca-google-cloud-kubernetes",
-      "stream-customer-acquisition"
+      "ct-google-cloud-kubernetes",
+      "stream-customer-trust"
     ]
   }
 }
@@ -979,15 +979,15 @@ team_parents = {
     review_request_delegation = true
   }
 
-  "stream-customer-acquisition" = {
-    description = "Stream Aligned Team: responsible for the Customer Acquisition stream and code reviews."
+  "stream-customer-trust" = {
+    description = "Stream Aligned Team: responsible for the Customer Trust stream and code reviews."
     maintainers = ["brettcurtis"]
     members     = []
     permission  = "push"
 
     repositories = [
-      "ca-google-cloud-kubernetes",
-      "stream-customer-acquisition"
+      "ct-google-cloud-kubernetes",
+      "stream-customer-trust"
     ]
   }
 

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -70,7 +70,7 @@ repositories = {
     description = "Kubernetes Infrastructure as Code (IaC) example for the Customer Trust stream-aligned team."
 
     topics = [
-      "customer-acquisition",
+      "customer-trust",
       "google-cloud-platform",
       "infrastructure-as-code",
       "kubernetes",
@@ -518,7 +518,7 @@ repositories = {
     enable_datadog_webhook   = false
 
     topics = [
-      "customer-acquisition",
+      "customer-trust",
       "osinfra",
       "stream-aligned-team"
     ]


### PR DESCRIPTION
Fixes #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated team and repository names to reflect the shift from "customer-acquisition" to "customer-trust."
	- Modified repository creation templates to align with the new team naming convention.
	- Concealed internal filenames and keys for confidentiality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->